### PR TITLE
jersey scan packages(..) is broken in connection with spring boot jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.joergdev</groupId>
 	<artifactId>mosy-backend-standalone</artifactId>
-	<version>3.0.0</version>
+	<version>3.0.1</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/src/main/java/de/joergdev/mosy/backend/standalone/JerseyConfig.java
+++ b/src/main/java/de/joergdev/mosy/backend/standalone/JerseyConfig.java
@@ -2,14 +2,34 @@ package de.joergdev.mosy.backend.standalone;
 
 import org.glassfish.jersey.server.ResourceConfig;
 import org.springframework.stereotype.Component;
+import de.joergdev.mosy.backend.api.impl.Globalconfig;
+import de.joergdev.mosy.backend.api.impl.Interfaces;
+import de.joergdev.mosy.backend.api.impl.MockData;
+import de.joergdev.mosy.backend.api.impl.MockProfiles;
+import de.joergdev.mosy.backend.api.impl.MockServices;
+import de.joergdev.mosy.backend.api.impl.RecordConfig;
+import de.joergdev.mosy.backend.api.impl.RecordSessions;
+import de.joergdev.mosy.backend.api.impl.Records;
 
 @Component
 public class JerseyConfig extends ResourceConfig
 {
-  public static final String API_IMPL_PACKAGE = "de.joergdev.mosy.backend.api.impl";
+  //  private static final String API_IMPL_PACKAGE = "de.joergdev.mosy.backend.api.impl";
 
   public JerseyConfig()
   {
-    packages(API_IMPL_PACKAGE);
+    register(Globalconfig.class);
+    register(Interfaces.class);
+    register(MockData.class);
+    register(MockProfiles.class);
+    register(MockServices.class);
+    register(RecordConfig.class);
+    register(Records.class);
+    register(RecordSessions.class);
+    register(de.joergdev.mosy.backend.api.impl.System.class);
+
+    // the jersey scan via packages(..) is actually broken in connection with spring boot jar
+    // so we have to register the API classes directly (see above)
+    //    packages(API_IMPL_PACKAGE);
   }
 }


### PR DESCRIPTION
so we have to register the API classes directly